### PR TITLE
Removes discussion already covered in launch events explainer

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -75,7 +75,7 @@ A LaunchEvent containing a sequence<[FileSystemFileHandle](https://github.com/WI
 `name` is the name of the file handler, as defined in the web app manifest. If the user selects files files with different handlers (e.g. a CSV and SVG file, in the case of Graphr), one LaunchEvent will be fired for each handler (though a handler could receive multiple files).
 
 
-A [FileSystemFileHandle](https://github.com/WICG/native-file-system/blob/master/EXPLAINER.md) allows reading and writing the file. (An earlier proposed API for file reading and writing was [FileEntry](https://www.w3.org/TR/2012/WD-file-system-api-20120417/#the-fileentry-interface) but work on that proposal has discontinued.).
+A [FileSystemFileHandle](https://github.com/WICG/native-file-system/blob/master/EXPLAINER.md) allows reading and writing the file.
 
 ### Launch Events
 

--- a/explainer.md
+++ b/explainer.md
@@ -90,13 +90,13 @@ App     | SW Launch   | Client Launch   | Description
 ------  | ----------- | --------------- | ---------
 VS Code | Yes         | No              | VSCode opens individual files in the last active window (fine for client launch events), unless a parent directory of the file is open in as a workspace, in which case, the file will be opened in the editor for that workspace. This cannot be handled by client events without undesirable focusing of some arbitrary client.
 Paint   | Yes         | Yes             | Always opens a new window.
-TextEdit| Yes         | No              | Opens files in a new window, if they aren't already open, otherwise focus the window that has the file open.
+TextEdit| Yes         | No              | Opens files in a new window, if the file isn't already open, otherwise focus the window that has the file open.
 Sublime | Yes         | Yes             | Configurable. Either always open in new window, or never open in new window.
 Chrome  | Yes        | Yes             | Open in last active window.
 
 It seems clear that there are at least some cases where it is useful for applications to be able to inspect already open clients and decide where they want a file to be opened. 
 
-Particularly interesting is that in some cases, the application exposes settings for what to do when new file is opened. We briefly considered a declarative API (e.g. Paint says to always open files in a new window in its manifest). This, however, would indicate that this is unlikely to be a workable approach.
+Particularly interesting is that in some cases, applications exposes settings for what to do when new file is opened. We briefly considered a declarative API (e.g. Paint says to always open files in a new window in its manifest). This, however, would indicate that this is likely not a workable approach.
 
 ### Previous Solutions
 There are a few similar, non-standard APIs, which it may be useful to compare this with.

--- a/explainer.md
+++ b/explainer.md
@@ -81,22 +81,7 @@ A [FileSystemFileHandle](https://github.com/WICG/native-file-system/blob/master/
 
 The intention of the launch events discussed in this explainer is that they be built on top of the more general [sw-launch](https://github.com/WICG/sw-launch/blob/master/explainer.md) proposal, as part of a unified system for handling application launches.
 
-### Concerns
-
-#### Will the current application behavior be supported?
-Below is a not-at-all scientific collection of how a few common apps handle files being opened. SW Launch refers to the case where we fire a launch event on the service worker, while client launch refers to a theoretical event handler on the client window.
-
-App     | SW Launch   | Client Launch   | Description
-------  | ----------- | --------------- | ---------
-VS Code | Yes         | No              | VSCode opens individual files in the last active window (fine for client launch events), unless a parent directory of the file is open in as a workspace, in which case, the file will be opened in the editor for that workspace. This cannot be handled by client events without undesirable focusing of some arbitrary client.
-Paint   | Yes         | Yes             | Always opens a new window.
-TextEdit| Yes         | No              | Opens files in a new window, if the file isn't already open, otherwise focus the window that has the file open.
-Sublime | Yes         | Yes             | Configurable. Either always open in new window, or never open in new window.
-Chrome  | Yes        | Yes             | Open in last active window.
-
-It seems clear that there are at least some cases where it is useful for applications to be able to inspect already open clients and decide where they want a file to be opened. 
-
-Particularly interesting is that in some cases, applications exposes settings for what to do when new file is opened. We briefly considered a declarative API (e.g. Paint says to always open files in a new window in its manifest). This, however, would indicate that this is likely not a workable approach.
+This could either build directly on top of launch events (by subclassing the launch event) or work via a navigation, similar to other triggers of launch events. More in depth discussion is available on the [sw-launch](https://github.com/WICG/sw-launch/blob/master/explainer.md#whether-launch-events-should-only-be-triggered-by-navigations) explainer.
 
 ### Previous Solutions
 There are a few similar, non-standard APIs, which it may be useful to compare this with.


### PR DESCRIPTION
There was significant overlap between the [launch events explainer](https://github.com/WICG/sw-launch/blob/master/explainer.md) and that in this explainer. This overlap has been removed.