### PR TITLE
Updates explainer to reflect that file handling should be separate from launch events.

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -47,14 +47,16 @@ On a system that does not use file extensions but associates files with MIME typ
 
 The user can right click on CSV or SVG files in the operating system's file browser, and choose to open the files with the Grafr web application. (This option would only be presented if Grafr has been [installed](https://w3c.github.io/manifest/#installable-web-applications).)
 
-This would create a new top level browsing context, navigating to '{origin}{open_url}'. Assuming the user opened `graph.csv` in Graphr the url would be something along the lines of `https://graphr.com/open-files`. When the `load` event is fired, an additional `launchParams` property will be available on the `EventArgs`, containing a list of the files that the application was launched with. Possibly we could use `DOMContentLoaded` or create a custom event type instead of using `load`.
+This would create a new top level browsing context, navigating to '{origin}{open_url}'. Assuming the user opened `graph.csv` in Graphr the url would be `https://graphr.com/open-files`. When the `load` event is fired, an additional `launchParams` property will be available on the `EventArgs`, containing a list of the files that the application was launched with.
 
-> Note: This method of getting launch parameters is somewhat different to what we do in other situations (for example, by posting shared files in WebShareTarget). This is because we need a FileSystemFileHandle object in order to write back to the file. If we redesigned the existing APIs today, I like to think we'd do something similar.
+> Note: Possibly we could use `DOMContentLoaded` or create a custom event type instead of using `load`.
 
-The `launchParams` object should look something like this:
+> Note: This method of getting launch parameters is somewhat different to what we do in other situations (for example, posting shared files in WebShareTarget). This is because we need a FileSystemFileHandle object in order to write back to the file, so we can't pass the file handle in as part of the url. If we redesigned the existing APIs today, I like to think we'd do something similar.
+
+The shape of `LaunchEvent` and `LaunchParams` is described below:
 ```cs
 interface LaunchParams {
-  // Cause of the launch (e.g. files|share|shortcut|link). Only files will be supported initially.
+  // Cause of the launch (e.g. files|share|shortcut|link). Only files will be supported initially but will likely be added in future.
   readonly attribute DOMString cause;
   // The files the application was launched with. 
   sequence<FileSystemFileHandle>? files;

--- a/explainer.md
+++ b/explainer.md
@@ -37,7 +37,7 @@ The following web application declares in its manifest that it can handle CSV an
     }
 ```
 
-> Note: Open url **MUST** be inside the app scope.
+> Note: `open_url` **MUST** be inside the app scope.
 
 Each accept entry is a sequence of MIME types and/or file extensions.
 

--- a/explainer.md
+++ b/explainer.md
@@ -72,6 +72,7 @@ An application could then extract the [FileSystemFileHandles](https://github.com
 
 ```js
 window.addEventListener('load', event => {
+  // Launch params could be undefined if the browser doesn't support it.
   if (!event.launchParams || !event.launchParams.cause === 'files')
     return;
 

--- a/explainer.md
+++ b/explainer.md
@@ -88,12 +88,6 @@ self.addEventListener('launch', event => {
 
   const fileHandles = event.launchParams.files;
 
-  // If there are no files, display a notification saying so:
-  if (!fileHandles.length) {
-    self.showNotification('No files to open!');
-    return;
-  }
-
   event.waitUntil(async () => {
     const allClients = await clients.matchAll();
     const client = allClients.filter(/*clever logic...*/)[0];
@@ -111,7 +105,7 @@ self.addEventListener('launch', event => {
 });
 ```
 
-> Note: The launch event is likely to have an aggressive timeout, so all File IO should be done in a client window.
+> Note: The launch event is likely to have an aggressive timeout, so all File IO should be done in a client window. The details are being considered in [sw-launch](https://github.com/WICG/sw-launch/blob/master/explainer.md#addressing-malicious-or-poorly-written-sites).
 
 ### Differences with Similar APIs on the Web
 
@@ -131,7 +125,7 @@ There are a few similar, non-standard APIs, which it may be useful to compare th
 
 #### [registerContentHandler](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/registerContentHandler)
 
-Register content handler was [deprecated](https://github.com/whatwg/html/issues/630) due to the lack of two interoperable implementations and the implementation that was available [did not conform to that standard](https://github.com/whatwg/html/commit/b143dbc2d16f3473fcadee377d838070718549d3). This API was only available in Firefox.
+Register content handler was [deprecated](https://blog.chromium.org/2016/08/from-chrome-apps-to-web.html) due to the lack of two interoperable implementations and the implementation that was available [did not conform to that standard](https://github.com/whatwg/html/commit/b143dbc2d16f3473fcadee377d838070718549d3). This API was only available in Firefox.
 
 Example usage, as per MDN
 ```js

--- a/explainer.md
+++ b/explainer.md
@@ -47,7 +47,7 @@ On a system that does not use file extensions but associates files with MIME typ
 
 The user can right click on CSV or SVG files in the operating system's file browser, and choose to open the files with the Grafr web application. (This option would only be presented if Grafr has been [installed](https://w3c.github.io/manifest/#installable-web-applications).)
 
-This would create a new top level browsing context, navigating to '{origin}{action}'. Assuming the user opened `graph.csv` in Graphr the url would be `https://graphr.com/open-files`. When the `load` event is fired, an additional `launchParams` property will be available on the event, containing a list of the files that the application was launched with.
+This would create a new top level browsing context, navigating to '{origin}{action}?name={HANDLER_NAME}'. Assuming the user opened `graph.csv` in Graphr the url would be `https://graphr.com/open-files/?name=raw`. When the `load` event is fired, an additional `launchParams` property will be available on the event, containing a list of the files that the application was launched with.
 
 > Note: Possibly we could use `DOMContentLoaded` or create a custom event type instead of using `load`.
 

--- a/explainer.md
+++ b/explainer.md
@@ -49,12 +49,12 @@ The user can right click on CSV or SVG files in the operating system's file brow
 
 This would create a new top level browsing context, navigating to '{origin}{action}?name={HANDLER_NAME}'. Assuming the user opened `graph.csv` in Graphr the url would be `https://graphr.com/open-files/?name=raw`. When the `load` event is fired, an additional `launchParams` property will be available on the event, containing a list of the files that the application was launched with.
 
-> Note: Possibly we could use `DOMContentLoaded` or create a custom event type instead of using `load`.
+> Note: `load` is possibly not the correct place for this. We are considering other options, including `DOMContentLoaded` or a completely new event.
 
 The shape of `LoadEvent` and `LaunchParams` is described below:
 ```cs
 interface LaunchParams {
-  // Cause of the launch (e.g. files|share|shortcut|link). Only files will be supported initially but will likely be added in future.
+  // Cause of the launch (e.g. file_handler|share_target|shortcut|link). Only files will be supported initially but will likely be added in future. This key would be based on the manifest entry, where appropriate.
   readonly attribute DOMString cause;
   // The files the application was launched with. 
   sequence<FileSystemFileHandle>? files;
@@ -111,7 +111,7 @@ self.addEventListener('launch', event => {
 
 It is worth noting that the proposed method of getting launched files is somewhat different to similar APIs on the web.
 
-- WebShareTarget: All relevant data is contained in the POST request to the page
+- Web Share Target: All relevant data is contained in the POST request to the page
 - registerProtocolHandler: Relevant data is contained in the query string the page navigates to
 
 In contrast, when we perform a navigation to the file-handling url, the files are not available as part of a request, so the page has to wait for an additional event to fire. We briefly considered encoding the `FileSystemFileHandles` in the query string in a blob-like format (e.g. `file-handle://<GUIDish>`). However, this presents some problems:

--- a/explainer.md
+++ b/explainer.md
@@ -16,7 +16,7 @@ There has historically been no standards-track API for MIME type handling. For s
 
 ### Example
 
-The following web application declares in its manifest that can handle CSV and SVG files.
+The following web application declares in its manifest that it can handle CSV and SVG files.
 
 ```json
     {

--- a/explainer.md
+++ b/explainer.md
@@ -122,7 +122,7 @@ It is worth noting that the proposed method of getting launched files is somewha
 
 In contrast, when we perform a navigation to the file-handling url, the files are not available as part of a request, so the page has to wait for an additional event to fire. We briefly considered encoding the `FileSystemFileHandles` in the query string in a blob-like format (e.g. `file-handle://<GUIDish>`). However, this presents some problems:
 - The page would have to parse file handles from the url itself, adding boilerplate.
-- Lifetimes for blob-like urls is complicated, as we can't predict when/where the handle will be used.
+- Lifetimes for blob-like urls are complicated, as we can't predict when/where the handle will be used.
 
 In addition, were we designing the existing APIs again today, there is a good change we might take this approach for them too.
 


### PR DESCRIPTION
Previously, we intended to handle files directly in the launch event. Now, the intention is to trigger a navigation, which launch events can handle naturally.

Note: [WebShareTarget](https://github.com/WICG/web-share-target/blob/master/docs/explainer.md#manifestwebmanifest) seems to use `action` instead of `open_url` in the manifest. I just changed this back to what @ewilligers had originally specified but I think we should probably update this to match.