### PR TITLE
Moves to a mimetype: [extensions] structure.

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -25,12 +25,28 @@ The following web application declares in its manifest that it can handle CSV an
         {
           "action": "/open-csv",
           "name": "Raw Graph",
-          "accept": [ ".csv", "text/csv" ]
-        }
+          "accept": {
+            "text/csv": [ ".csv" ]
+          }
+        },
         {
           "action": "/open-svg",
           "name": "SVG Graph",
-          "accept": [ ".svg", "text/svg+xml" ]
+          "accept": {
+            "image/svg+xml": ".svg",
+          }
+        },
+        {
+          "action": "/open-graf",
+          "name": "Grafr File",
+          "accept": {
+            "application/vnd.grafr.graph": [
+              ".grafr", ".graf"
+            ],
+            "application/vnd.alternative-graph-app.graph": [
+              ".graph",
+            ]
+          }
         }
       ]
     }
@@ -38,11 +54,11 @@ The following web application declares in its manifest that it can handle CSV an
 
 > Note: `action` must be inside the app scope.
 
-Each accept entry is a sequence of MIME types and/or file extensions.
+Each accept entry is a dictionary mapping mimetypes to extensions. This ensures applications will still work on operating systems that only support one of the two.
 
-On platforms that only use file extensions to describe file types, user agents can match on the extensions ".csv" and ".svg".
+On platforms that only use file extensions to describe file types, user agents can match on the extensions ".csv", ".svg", ".grafr", ".graf" and ".graph".
 
-On a system that does not use file extensions but associates files with MIME types, user agents can match on the "text/csv" and "image/svg+xml" MIME types. If the web application accepts all text and image formats that the browser supports, "text/\*" and "image/\*" could be used, i.e. "\*" may appear in place of a subtype. "\*/\*" can be used if all files are accepted.
+On a system that does not use file extensions but associates files with MIME types, user agents can match on the "text/csv", "image/svg+xml", "application/vnd.grafr.graph" and "application/vnd.alternative-graph-app.graph" MIME types. If the web application accepts all text and image formats that the browser supports, "text/\*" and "image/\*" could be used, i.e. "\*" may appear in place of a subtype. "\*/\*" can be used if all files are accepted.
 
 The user can right click on CSV or SVG files in the operating system's file browser, and choose to open the files with the Grafr web application. (This option would only be presented if Grafr has been [installed](https://w3c.github.io/manifest/#installable-web-applications).). The user agent should use `${file_handler}.${name}` in the entry it shows in the operating system file browser. For example, when right clicking a CSV file the user might see the option to open it with `"Grafr: Raw Graph"`.
 

--- a/explainer.md
+++ b/explainer.md
@@ -54,11 +54,11 @@ The following web application declares in its manifest that it can handle CSV an
 
 > Note: `action` must be inside the app scope.
 
-Each accept entry is a dictionary mapping mimetypes to extensions. This ensures applications will still work on operating systems that only support one of the two.
-
-On platforms that only use file extensions to describe file types, user agents can match on the extensions ".csv", ".svg", ".grafr", ".graf" and ".graph".
+Each accept entry is a dictionary mapping mimetypes to extensions. This ensures applications will still work on operating systems that only support one of the two. This also allows applications to register custom file types on all platforms (even Linux, which [only supports mimetypes](https://stackoverflow.com/a/31836/3260044)).
 
 On a system that does not use file extensions but associates files with MIME types, user agents can match on the "text/csv", "image/svg+xml", "application/vnd.grafr.graph" and "application/vnd.alternative-graph-app.graph" MIME types. If the web application accepts all text and image formats that the browser supports, "text/\*" and "image/\*" could be used, i.e. "\*" may appear in place of a subtype. "\*/\*" can be used if all files are accepted.
+
+On platforms that only use file extensions to describe file types, user agents can match on the extensions ".csv", ".svg", ".grafr", ".graf" and ".graph".
 
 The user can right click on CSV or SVG files in the operating system's file browser, and choose to open the files with the Grafr web application. (This option would only be presented if Grafr has been [installed](https://w3c.github.io/manifest/#installable-web-applications).). The user agent should use `${file_handler}.${name}` in the entry it shows in the operating system file browser. For example, when right clicking a CSV file the user might see the option to open it with `"Grafr: Raw Graph"`.
 


### PR DESCRIPTION
On platforms that only support mime based file handlers (e.g. Linux), there is no way of defining a custom mime type (e.g. application/vnd.my-app.type). This proposes a solution where mimetypes are always mapped to a list of extensions.

Fixes #26.