### PR TITLE
Add periods to the end of bullet points.

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -103,12 +103,12 @@ For more advanced use cases, such as opening a file in an existing window or dis
 
 The proposed method of getting launched files differs from some similar web APIs:
 
-- Web Share Target: All relevant data is contained in the POST request to the page
-- registerProtocolHandler: Relevant data is contained in the query string the page navigates to
+* Web Share Target: All relevant data is contained in the POST request to the page.
+* registerProtocolHandler: Relevant data is contained in the query string the page navigates to.
 
 In contrast, when we perform a navigation to the file-handling URL, the files are not available as part of a request. We briefly considered encoding the `FileSystemFileHandles` in the query string in a blob-like format (e.g. `file-handle://<GUIDish>`). However, this presents some problems:
-- The page would have to parse file handles from the URL itself, adding boilerplate.
-- Lifetimes for blob-like URLs are complicated, as we can't predict when/where the handle will be used.
+* The page would have to parse file handles from the URL itself, adding boilerplate.
+* Lifetimes for blob-like URLs are complicated, as we can't predict when/where the handle will be used.
 
 In addition, were we designing the existing APIs again today, there is a good chance we might take this approach for them too.
 


### PR DESCRIPTION
For consistency, have periods at the end of all bullet points, and start bullet points with the '*' character (as opposed to the '-' character).

Following up to improve consistency from https://github.com/WICG/file-handling/pull/48