### PR TITLE
Updates to explainer to reflect security changes

### DIFF
--- a/PRIVACY_AND_SECURITY.md
+++ b/PRIVACY_AND_SECURITY.md
@@ -2,12 +2,12 @@
 
 ### 3.1 Does this specification deal with personally-identifiable information?
 
-No (though it is conceivable that a user could open sensitive information in a web app, perhaps editing their tax return in a web app made for that prupose).
+Indirectly: it is conceivable that a user could open sensitive information in a web app, perhaps editing their tax return in a web app made for that purpose.
 
 
 ### 3.2 Does this specification deal with high-value data?
 
-Yes. It will grant read (and possibly write) access to some of a user's files (if they choose to open them with a PWA). 
+Yes. It will grant read and write access to some of a user's files (if they choose to open them with a PWA).
 
 
 ### 3.3 Does this specification introduce new state for an origin that persists across browsing sessions?
@@ -17,7 +17,7 @@ No.
 
 ### 3.4 Does this specification expose persistent, cross-origin state to the web?
 
-Yes, in the form of access to the native file system. Note, however, that the user must have both origins installed as PWAs and must **explicitly** open the same file with both web apps.
+Yes, in the form of the contents of the native file system. Note, however, that the user must have both origins installed as PWAs and must **explicitly** open the same file with both web apps.
 
 ### 3.5 Does this specification expose any other data to an origin that it doesn’t currently have access to?
 
@@ -52,7 +52,7 @@ No.
 
 ### 3.11 Does this specification allow an origin some measure of control over a user agent’s native UI?
 
-No.
+No, however it does allow an installed app some measure of control over operating system native UI.
 
 
 ### 3.12 Does this specification expose temporary identifiers to the web?
@@ -72,7 +72,7 @@ Sites may not be registered as a file handler unless they are installed, which i
 
 ### 3.15 Does this specification persist data to a user’s local device?
 
-Not directly, but once a site has been granted write access to a file it may persist data. The duration of access to files is undecided but we will defer to what is decided by the [native-file-system](https://github.com/WICG/native-file-system/blob/master/EXPLAINER.md) folks.
+Not directly, but once a site has been granted write access to a file it may persist data. The duration of access to files is controlled by the [File System Access API](https://github.com/WICG/native-file-system/blob/master/EXPLAINER.md).
 
 
 ### 3.16 Does this specification have a "Security Considerations" and "Privacy Considerations" section?

--- a/explainer.md
+++ b/explainer.md
@@ -2,21 +2,23 @@
 
 Authors: 
 * Current:
-  * Darwin Huang &lt;<huangdarwin@chromium.org>&gt;
+  * Evan Stade &lt;<estade@chromium.org>&gt;
 * Former:
+  * Darwin Huang &lt;<huangdarwin@chromium.org>&gt;
   * Eric Willigers &lt;<ericwilligers@chromium.org>&gt;<br>
   * Jay Harris &lt;<harrisjay@chromium.org>&gt;<br>
   * Raymes Khoury &lt;<raymes@chromium.org>&gt;
 
 ## Motivation
 
-This proposal gives installed web applications a way to register their ability to handle (read, stream, edit) files with given MIME types and/or file extensions. This then allows an operating system's file manager or other operating system flows to select a PWA to handle the file using a PWA, similar to how it would handle the file using some other associated installed app.
+This proposal gives installed web applications a way to register their ability to handle (read, stream, edit) files with given MIME types and/or file extensions. This then allows an operating system's file manager or other operating system flows to use a PWA to handle opening the file, similar to how it would open the file using a native app.
 
 This has many use cases. For example:
 * A document editor could display and edit a number of document formats, like `.txt`, `.md`, `.csv`, and `.docx`.
 * A movie player could play a video format.
 * A Javascript development environment could interactively step through Javascript programs.
-* A data visualizer could generate graphs from .CSV files.
+* A data visualizer could generate graphs from `.csv` files.
+* A creative tool could generate files in a proprietary format and become the default handler for such files (opening when a user double clicks on `.foo` in the system file browser).
 
 There has historically been no standards-track API for MIME type handling. For some years, [Chrome packaged apps](https://developer.chrome.com/docs/extensions/apps/) have been able to register one or more file handlers using a [Chrome-specific API](https://developer.chrome.com/apps/manifest/file_handlers) where each handler may handle specific MIME types and/or file extensions. As of August 2018, 619 file handlers handled MIME types, while 509 file handlers handled file extensions. Some packaged apps had more than one file handler. Overall, 580 packaged apps handled MIME types and 337 packaged apps handled file extensions. This usage, and the use cases above, demonstrates the value of being able to associate web applications with MIME types and/or file extensions.
 
@@ -54,7 +56,7 @@ The following web application declares in its manifest that it can handle CSV an
               "src": "/svg-file.png",
               "sizes": "144x144"
             }
-          ]        
+          ]
         },
         {
           "action": "/open-graf",
@@ -73,41 +75,17 @@ The following web application declares in its manifest that it can handle CSV an
 
 The new manifest API surface is contained in the `file_handlers` list, where each entry in this list is a dictionary describing the file handler, with fields like `action`, `name`, `accept`, and `icons`.
 
-`action` must be inside the app scope, and specifies the URL after the origin, later navigated to in the launch event when handling a file.
+`action` must be inside the app scope, and specifies the URL after the origin that is the navigation destination for file handling launches (analogous to `start_url` for typical app launches).
 
-Each `accept` entry is a dictionary mapping MIME types to extensions. This ensures applications will work on operating systems that only support one of the two (example: Linux, which [only supports MIME types](https://stackoverflow.com/a/31836/3260044)). This also allows applications to register custom file types.
+Each `accept` entry is a dictionary mapping MIME types to extensions. Depending on context, both MIME type and file extension may be important. For example, `xdg-utils` on Linux [associates files to apps via MIME types](https://stackoverflow.com/a/31836/3260044), and thus (a) will match files to apps based on MIME type, and (b) requires all file extensions to map to a known MIME type (custom file formats like the `.grafr` example need a MIME type). Other systems map directly from file extension to app. For consistency across platforms, the user agent will enforce that the app can only open files with specified extensions. App authors should expect that both the MIME type *and* file extension must match for a file to be openable by an app.
 
-On a system that does not use file extensions but associates files with MIME types, user agents can match on the `"text/csv"`, `"image/svg+xml"`, `"application/vnd.grafr.graph"` and `"application/vnd.alternative-graph-app.graph"` MIME types. If the web application accepts all text and image formats that the browser supports, `"text/*"` and `"image/*"` could be used, i.e. `"*"` may appear in place of a subtype. `"*/*"` can be used if all files are accepted. On platforms that only use file extensions to describe file types, user agents can match on the extensions `".csv"`, `".svg"`, `".grafr"`, `".graf"` and `".graph"`.
-
-Icons will be registered for each handler based on the optional `icons` entry, which expects [`ImageResource`](https://www.w3.org/TR/image-resource/)s to specify the images. If an icon is provided in an `icons` entry, that image will be registered in the operating system for that file type. Otherwise, the image registered will be the web application's icon as specified in the manifest.
-
-After the user [installs](https://w3c.github.io/manifest/#installable-web-applications) Grafr, the operating system UX flows, including file managers and "Open with..." dialogs, should list Grafr as an application that may be used to open files of this file type. In this listing, the `"name"`should be listed as an option, to be associated with the registered icon corresponding to this file type. The user can then right click on CSV or SVG files in the operating system's file browser, and choose to open the files with the Grafr web application. When the user uninstalls this web application, registered file handlers and icons will be properly uninstalled as well.
+`name` and `icons` are a string and [`ImageResource`](https://www.w3.org/TR/image-resource/) array, respectively, which describe the file type. These *may* be used to describe the files in file browsers and other contexts, depending on the operating system and other factors such as whether the PWA is the default handler for the file type.
 
 ## Launch
 
 Choosing to open the file would create a new top level browsing context, navigating to the `action` URL (resolved against the manifest URL). Assuming the user opened `graph.csv` in Grafr the URL would be `https://grafr.com/open-csv/`.
 
-To access launched files, a site should specify a consumer for a `launchQueue` object attached to `window`. Launches are queued until they are handled by this consumer, which is invoked exactly once for each launch. In this manner, we can ensure every launch is handled, regardless of when the consumer was specified. The application will have read access through the [File System Access](https://github.com/WICG/file-system-access/blob/master/EXPLAINER.md) API, but will need to separately request write access from the user to edit the file.
-
-`launchQueue`, `launchParams`, and the DOM Window they're used on, are specified as follows:
-```
-// DOM Window Launch Queue.
-partial interface Window {
-    readonly attribute LaunchQueue launchQueue;
-};
-
-// Launch Queue.
-[Exposed=Window] interface LaunchQueue {
-  void setConsumer(LaunchConsumer consumer);
-};
-
-callback LaunchConsumer = any (LaunchParams params);
-
-// Launch Params.
-[Exposed=Window] interface LaunchParams {
-  readonly attribute FrozenArray<FileSystemHandle> files;
-};
-```
+To access launched files, a site should specify a consumer for a `launchQueue` object attached to `window`. See: [`launch_handler`](https://github.com/WICG/sw-launch/blob/main/launch_handler.md). The application will have read/write access through the [File System Access](https://github.com/WICG/file-system-access/blob/master/EXPLAINER.md) API.
 
 Below is a basic example of using `launchQueue` and `launchParams` to receive the file handles.
 ```js
@@ -123,24 +101,30 @@ if ('launchQueue' in window) {
   });
 }
 ```
-An application could then choose to handle these files however it chose. For example, it could save the file handle to disk and create a URL to address the launched file, allowing users to navigate back to a file.
+An application could then choose to handle these files however it chose. For example, it could open the file contents in an editor and allow saving edits back to disk.
 
-The `launchParams` property API design is discussed in more detail in the [Launch Events](https://github.com/WICG/sw-launch/blob/main/explainer.md) explainer [issue](https://github.com/WICG/sw-launch/issues/20).
+# Security and Privacy Considerations
 
-For more advanced use cases, such as opening a file in an existing window or displaying a notification, applications can add a [launch event handler](https://github.com/WICG/sw-launch/blob/master/explainer.md).
+There is a large category of attack vectors that are opened up by allowing websites access to files. These are dealt with in the [file-system-access](https://github.com/WICG/file-system-access/blob/main/EXPLAINER.md#proposed-security-models) explainer.
 
-## Permissions API Integration
+The additional security-pertinent capability that this specification provides over the file-system-access API is the ability to grant access to certain files through the operating system UI, as opposed to through a file picker shown by a web application. Any restrictions as to the files and folders that can be opened via the picker may also be applied to the files and folders opened via the operating system.
 
-A `"file-handling"` permission will be defined to protect the user from accidentally allowing a PWA to view files. This permission prompt may asynchronously show right after the user chooses to use a PWA to open a file of any of the file types the PWA tries to associate with, so that the permission context is more understandable and relevant. This permission prompt should also show after the PWA has had an opportunity to load. The prompt should clearly show the PWA's origin, so that the identity of the PWA requesting file read access for the handled file is clear to the user. Launched files should only be queued into the `launchQueue` after the user accepts the permission and allows the PWA to handle the relevant file types. User agents may retain control over default settings and how (or if) they are exposed to the user.
+As with native apps, an app's ability to handle a specified file type will be registered with the OS at install time. However, as an additional protection to safeguard against accidental sharing of sensitive information contained in local files, the user agent may initially verify that the action is intentional. As a run-time confirmation, this step follows a flow similar to most web Permissions. The verification prompt should appear before the PWA is launched and the launch should be aborted if the user denies the action. User agents may retain control over default settings and how (or if) they are exposed to the user.
 
-## Differences with Similar APIs on the Web
+See the [File Handling Security Model](https://docs.google.com/document/d/1pTTO5MTSlxuqxpWL3pFblKB8y8SR0jPao8uAjJSUTp4) for more discussion of the threat model. Additional details are also available in the [Security and Privacy Questionnaire](https://github.com/WICG/file-handling/blob/main/PRIVACY_AND_SECURITY.md).
+
+# Addendum
+
+## Differences to Similar APIs on the Web
 
 The proposed method of getting launched files differs from some similar web APIs:
 
 * Web Share Target: All relevant data is contained in the POST request to the page.
 * registerProtocolHandler: Relevant data is contained in the query string the page navigates to.
 
-In contrast, when we perform a navigation to the file-handling URL, the files are not available as part of a request. We briefly considered encoding the `FileSystemFileHandles` in the query string in a blob-like format (e.g. `file-handle://<GUIDish>`). However, this presents some problems:
+In contrast, when we perform a navigation to the file-handling URL, the files are not available as part of a request. Since many apps that make use of the File Handling API will also make use of the [File System Access API](https://github.com/WICG/file-system-access/blob/main/EXPLAINER.md), reusing the `FileSystemFileHandle` part of that API should enable greater code reuse.
+
+We briefly considered encoding the `FileSystemFileHandles` in the query string in a blob-like format (e.g. `file-handle://<GUIDish>`). However, this presents some problems:
 * The page would have to parse file handles from the URL itself, adding boilerplate.
 * Lifetimes for blob-like URLs are complicated, as we can't predict when/where the handle will be used.
 
@@ -246,27 +230,6 @@ function onActivatedHandler(eventArgs) {
     // The first file is eventArgs.detail.files[0] 
 } 
 ```
-
-# Security and Privacy Considerations
-
-There is a large category of attack vectors that are opened up by allowing websites access to files. These are dealt with in the [file-system-access](https://github.com/WICG/file-system-access/blob/main/EXPLAINER.md#proposed-security-models) explainer.
-
-The additional security-pertinent capability that this specification provides over the file-system-access API is the ability to grant access to certain files through the operating system UI, as opposed to through a file picker shown by a web application. Any restrictions as to the files and folders that can be opened via the picker may also be applied to the files and folders opened via the operating system.
-
-There is still a risk that users may unintentionally grant a web application access to a file by opening it. However, it is generally understood that opening a file allows the application it is opened with to read and/or manipulate that file. Therefore, a user's explicit choice to open a file in an installed application, such as via an “Open with...” context menu, can be read as a signal of trust in the application. In conjunction with a permission prompt, this can be viewed as sufficient trust to let the web application view the file.
-
-More details are also available in the [Security and Privacy Questionnaire](https://github.com/WICG/file-handling/blob/main/PRIVACY_AND_SECURITY.md)
-
-### Accidental default association
-
-The exception to this is where there are no existing applications installed on the host operating system capable of handling a given file type. In this case, some host OSes may automatically promote the newly registered handler to become the default handler for that file type, silently and without any intervention by the user. Currently, this can occur in all desktop OSes. This would mean if the user double-clicks a file of that type, it would automatically open in the registered web app. On such host OSes, when the user agent determines that there is no existing default handler for the file type, an explicit permission prompt might be necessary, to avoid accidentally sending the contents of a file to a web application without the user's consent.
-
-### Mitigations
-
-The following mitigations are recommended.
-* User agents should not register every site that can handle files as a file handler. Instead, registration should be gated behind installation. Users expect installed applications to be more deeply integrated with the OS. 
-* Users agents should not register web applications as the default file handler for any file type without explicit user confirmation.
-* A permissions prompt should be displayed before registering a web application as the default handler for a type where that registration would otherwise happen without the user's intervention (such as in the situation discussed above). Alternatively, a permissions prompt could be displayed the first time (or every time) the user opens a file with the automatically-registered default handler.
 
 ## References:
 * [Ballista (earlier, related proposal) explainer](https://github.com/chromium/ballista/blob/master/docs/explainer.md).


### PR DESCRIPTION
- Note that the file handle's access is read/write.
- Remove references to Permissions API, since API is no longer integrated with Permissions.
- Clarify meaning of MIME types and file extensions
- Reorganize for clarity (pull security discussion above "alternatives considered")