### PR TITLE
Note integration in Manifest Incubations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
-# File Handling
+# Former home of File Handling
 
-**Date**: 2018-09-25
+This repository formerly hosted a proposed capability for web applications to support File Handling, now integrated in [Manifest Incubations](https://wicg.github.io/manifest-incubations/index.html#file_handlers-member), hosted in the [WICG/manifest-incubations](https://github.com/WICG/manifest-incubations/) repository.
 
-This is the repository for a proposed capability for web applications to support File Handling.
-
-Please see the [Explainer document](explainer.md), a high-level overview of the proposal.
-
-You're welcome to [contribute](CONTRIBUTING.md)!
+Please see the former [Explainer document](explainer.md) for a high-level overview of the proposal.


### PR DESCRIPTION
As far as I can tell, the proposal was integrated in Manifest Incubations. This updates the README to note that integration. The pepository can probably be archived afterwards!